### PR TITLE
Change install path to a standard one

### DIFF
--- a/makefile
+++ b/makefile
@@ -14,7 +14,7 @@ LFLAGS := -lm -shared -lcrypto -lssl
 LINKER := $(CC)
 
 TARGET := lullaby.so
-INSTALL_DIR := /usr/lib64/lua/
+INSTALL_DIR := /usr/local/lib/lua/
 
 SRCS := $(wildcard src/*.c) $(wildcard src/*/*.c)
 OBJS := $(SRCS:.c=.o)

--- a/readme.md
+++ b/readme.md
@@ -41,7 +41,7 @@ build with `make`, output is `./lullaby.so` or (win)`./lullaby.dll`
 
 windows works through msys2, install `mingw-w64-x86_64-lua` then run `make CC=gcc`
 
-you can install with `doas make install` which will install lullaby.so into /usr/lib64/lua/5.X/
+you can install with `doas make install` which will install lullaby.so into /usr/local/lib/lua/5.X
 
 lua version can be specified with `version=...`, similar to 5.1, 5.3, jit, the default it 5.4
 


### PR DESCRIPTION
`/usr/lib64` isn't supported by Lua on Debian-based Linux distributions.