### PR TITLE
Fix sum stuffs

### DIFF
--- a/makefile
+++ b/makefile
@@ -28,11 +28,13 @@ else
 	CFLAGS += -fPIC
 endif
 
+.PHONY: all
 all: $(TARGET)
 
 release: CFLAGS += -O3
 release: all
 
+.PHONY: install
 install::
 	mkdir $(INSTALL)$(install_version) -p
 	cp $(TARGET) $(INSTALL)$(install_version)/$(TARGET)
@@ -68,5 +70,8 @@ reg: all
 $(TARGET): $(OBJS)
 	$(LINKER) $(OBJS) -o $(TARGET) $(LFLAGS) 
 
+.PHONY: clean
 clean: 
 	rm -f $(OBJS)
+
+

--- a/src/net/util.c
+++ b/src/net/util.c
@@ -413,7 +413,10 @@ void parse_mimetypes(){
   mime_type = map_init();
 
   FILE* fp = fopen(_mimetypes, "r");
-  if(fp == NULL) return (void)printf("unable to load mimetypes, set llby.net.mimetypes to a proper location, or nil to skip this\n");
+  if(fp == NULL){
+    fprintf(stderr, "unable to load mimetypes, set llby.net.mimetypes to a proper location, or nil to skip this\n");
+    return;
+  }
 
   char* line = NULL;
   size_t len = 0;

--- a/src/types/str.c
+++ b/src/types/str.c
@@ -35,7 +35,7 @@ str* str_init(const char* init){
 
 void str_free(str* s){
   free(s->c);
-  return free(s);
+  free(s);
 }
 
 void str_push(str* s, const char* insert){


### PR DESCRIPTION
Fix sum stuffs mainly just compiler warnings
__attribute__((unused)) makes no effect to the output binary so it shouldn't matter if at some point the parameters do need to be used but they are still marked as unused