### PR TITLE
Add extra hardening

### DIFF
--- a/makefile
+++ b/makefile
@@ -12,6 +12,8 @@ endif
 
 CFLAGS := -D_GNU_SOURCE -Wall -fPIC -DGIT_COMMIT='$(GIT_COMMIT)' -DMAJOR_VERSION='$(MAJOR_VERSION)' `pkg-config --cflags lua$(version)`
 LFLAGS := -lm -shared -lcrypto -lssl
+HARDENING_CFLAGS := -D_FORTIFY_SOURCE=2 -fstack-protector-strong -fstack-clash-protection
+HARDENING_LFLAGS := -Wl,-z,relro -Wl,-z,now -Wl,-z,noexecstack
 LINKER := $(CC)
 
 TARGET := lullaby.so
@@ -33,6 +35,13 @@ all: $(TARGET)
 
 release: CFLAGS += -O3
 release: all
+
+hardened: CFLAGS += -O2
+ifneq ($(OS),Windows_NT)
+hardened: CFLAGS += $(HARDENING_CFLAGS)
+hardened: LFLAGS += $(HARDENING_LFLAGS)
+endif
+hardened: all
 
 .PHONY: install
 install::

--- a/src/net/lua.c
+++ b/src/net/lua.c
@@ -187,6 +187,7 @@ int l_roll(lua_State* L){
   luaI_tsetv(L, 1, "files", files_idx);
 
   free(buffer);
+  buffer=NULL;
   lua_pushinteger(L, r);
   return 1;
 }
@@ -269,6 +270,7 @@ int l_sendfile(lua_State* L){
   }
 
   free(buffer);
+  buffer=NULL;
   fclose(fp);
 
   return 0;

--- a/src/net/util.c
+++ b/src/net/util.c
@@ -188,6 +188,7 @@ void http_build(str** _dest, int code, const char* code_det, char* header_vs, ch
   str_pushl(*_dest, content, len);
 
   free(dest);
+  dest=NULL;
 }
 
 /**
@@ -356,6 +357,7 @@ int match_param(char* path, char* match, parray_t* arr){
           memcpy(out, match + start, mi - start);
           parray_set(arr, name, out);
           free(name);
+          name=NULL;
         } else {
           mi++;
         }
@@ -368,6 +370,7 @@ int match_param(char* path, char* match, parray_t* arr){
     memcpy(out, match + start, mi - start);
     parray_set(arr, name, out);
     free(name);
+    name=NULL;
   }
 
   if(path[pi] != 0) for(; path[pi] == '*'; pi++);
@@ -450,6 +453,8 @@ void parse_mimetypes(){
     }
     free(mtype);
     free(type);
+    mtype=NULL;
+    type=NULL;
   }
 
   fclose(fp);
@@ -481,6 +486,7 @@ void _parse_mimetypes(){
     //check if the type has an associated file type
     if(buffer[i + type_len] == '\0' || buffer[i + type_len] == '\n'){
       free(type);
+      type=NULL;
       continue;
     }
     type = realloc(type, (type_len + 1) * sizeof * type);
@@ -511,9 +517,13 @@ void _parse_mimetypes(){
       }
     }
     free(file_type);
+    file_type=NULL;
 
     //printf("e: '%s'\n", type);
-    if(!used)free(type);
+    if(!used){
+      free(type);
+      type=NULL;
+    }
   }
   //printf("done\n");
 


### PR DESCRIPTION
### src/net pointer hardening
Sets pointers to NULL after free() in `src/net`, free(NULL) is a no-op making double free safe and will make use-after-frees more obvious by trying to use NULL as an address which should cause an immediate crash instead of continuing in an undefined state

### Adds compiler hardening option (non-windows):
`-fstack-protector-strong`
`-fstack-clash-protection`
`-D_FORTIFY_SOURCE=2`: adds bounds checks to potentially insecure functions handling arrays / strings

#### linker hardening options (non-windows):
`-Wl,-z,relro -Wl,-z,now` full RELRO support
`-Wl,-z,noexecstack` force non-executable stack